### PR TITLE
renam namespace

### DIFF
--- a/UriConvert.Test/UriConvert.Test.csproj
+++ b/UriConvert.Test/UriConvert.Test.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <RootNamespace>Ycode.UriConvert</RootNamespace>
+    <RootNamespace>Ycode.Uri.Test</RootNamespace>
     <BaseDirectory>src</BaseDirectory>
   </PropertyGroup>
 

--- a/UriConvert.Test/src/UriBaseAttributeTest.cs
+++ b/UriConvert.Test/src/UriBaseAttributeTest.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using NUnit.Framework;
 
-namespace Ycode.UriConvert
+namespace Ycode.Uri.Test
 {
     [TestFixture]
     public class UriBaseAttributeTest

--- a/UriConvert.Test/src/UriConvertTest.cs
+++ b/UriConvert.Test/src/UriConvertTest.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using NUnit.Framework;
 
-namespace Ycode.UriConvert
+namespace Ycode.Uri.Test
 {
     [TestFixture]
     class UriConvertTest

--- a/UriConvert.Test/src/UriIgnoreAttributeTest.cs
+++ b/UriConvert.Test/src/UriIgnoreAttributeTest.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using NUnit.Framework;
 
-namespace Ycode.UriConvert
+namespace Ycode.Uri.Test
 {
     [TestFixture(TestOf = typeof(UriIgnoreAttribute))]
     public class UriIgnoreAttributeTest

--- a/UriConvert.Test/src/UriPathAttributeTest.cs
+++ b/UriConvert.Test/src/UriPathAttributeTest.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using NUnit.Framework;
 
-namespace Ycode.UriConvert
+namespace Ycode.Uri.Test
 {
     [TestFixture]
     public class UriPathAttributeTest

--- a/UriConvert.Test/src/UriQueryParameterAttributeTest.cs
+++ b/UriConvert.Test/src/UriQueryParameterAttributeTest.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using NUnit.Framework;
 
-namespace Ycode.UriConvert
+namespace Ycode.Uri.Test
 {
     [TestFixture(TestOf = typeof(UriQueryParameterAttribute))]
     public class UriQueryParameterAttributeTest
@@ -167,7 +167,7 @@ namespace Ycode.UriConvert
 
             Assert.That(e, Is.Not.Null);
             Assert.That(e.GetType(), Is.EqualTo(typeof(InvalidOperationException)));
-            Assert.That(e.Message, Is.EqualTo("There are duplicates in query parameters in type Ycode.UriConvert.UriQueryParameterAttributeTest+DummyUriModel6." +
+            Assert.That(e.Message, Is.EqualTo("There are duplicates in query parameters in type Ycode.Uri.UriQueryParameterAttributeTest+DummyUriModel6." +
                                               " Query parameter name \"Param1\" is used by property Param0 and Param1." +
                                               " Query parameter name \"Param3\" is used by property Param2 and Param3."));
         }
@@ -203,7 +203,7 @@ namespace Ycode.UriConvert
             Assert.That(e.GetType(), Is.EqualTo(typeof(InvalidOperationException)));
             Assert.That(e.Message, Is.EqualTo("Query parameter with empty name was found"
                  + " with property Param0 and Param2"
-                 + " in type Ycode.UriConvert.UriQueryParameterAttributeTest+DummyUriModel7."));
+                 + " in type Ycode.Uri.UriQueryParameterAttributeTest+DummyUriModel7."));
         }
     }
 }

--- a/UriConvert.Test/src/UriQueryParameterAttributeTest.cs
+++ b/UriConvert.Test/src/UriQueryParameterAttributeTest.cs
@@ -167,7 +167,7 @@ namespace Ycode.Uri.Test
 
             Assert.That(e, Is.Not.Null);
             Assert.That(e.GetType(), Is.EqualTo(typeof(InvalidOperationException)));
-            Assert.That(e.Message, Is.EqualTo("There are duplicates in query parameters in type Ycode.Uri.UriQueryParameterAttributeTest+DummyUriModel6." +
+            Assert.That(e.Message, Is.EqualTo("There are duplicates in query parameters in type Ycode.Uri.Test.UriQueryParameterAttributeTest+DummyUriModel6." +
                                               " Query parameter name \"Param1\" is used by property Param0 and Param1." +
                                               " Query parameter name \"Param3\" is used by property Param2 and Param3."));
         }
@@ -203,7 +203,7 @@ namespace Ycode.Uri.Test
             Assert.That(e.GetType(), Is.EqualTo(typeof(InvalidOperationException)));
             Assert.That(e.Message, Is.EqualTo("Query parameter with empty name was found"
                  + " with property Param0 and Param2"
-                 + " in type Ycode.Uri.UriQueryParameterAttributeTest+DummyUriModel7."));
+                 + " in type Ycode.Uri.Test.UriQueryParameterAttributeTest+DummyUriModel7."));
         }
     }
 }

--- a/UriConvert/UriConvert.csproj
+++ b/UriConvert/UriConvert.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <BaseDirectory>src</BaseDirectory>
-    <RootNamespace>Ycode.UriConvert</RootNamespace>
+    <RootNamespace>Ycode.Uri</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/UriConvert/src/UriBaseAttribute.cs
+++ b/UriConvert/src/UriBaseAttribute.cs
@@ -2,6 +2,15 @@
 
 namespace Ycode.UriConvert
 {
+    [Obsolete(UriConvert.ObsoleteMessage)]
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    public class UriBaseAttribute : Ycode.Uri.UriBaseAttribute
+    {
+    }
+}
+
+namespace Ycode.Uri
+{
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
     public class UriBaseAttribute : Attribute
     {

--- a/UriConvert/src/UriConvert.cs
+++ b/UriConvert/src/UriConvert.cs
@@ -1,11 +1,28 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Reflection;
 
 namespace Ycode.UriConvert
+{
+    [Obsolete(ObsoleteMessage)]
+    public static class UriConvert
+    {
+        internal const string ObsoleteMessage = "Namespace Ycode.UriConvert has been renamed Ycode.Uri. Please use the new namespace.";
+
+        public static string SerializeObject(object value)
+            => Ycode.Uri.UriConvert.SerializeObject(value);
+
+        public static System.Uri Convert(object value)
+            => Ycode.Uri.UriConvert.Convert(value);
+
+        public static IDictionary<string, string> ExtractQueryParameters(object value, bool isToEncode = false)
+            => Ycode.Uri.UriConvert.ExtractQueryParameters(value, isToEncode);
+    }
+}
+
+namespace Ycode.Uri
 {
     public static class UriConvert
     {
@@ -20,7 +37,7 @@ namespace Ycode.UriConvert
             return Convert(value).AbsoluteUri;
         }
 
-        public static Uri Convert(object value)
+        public static System.Uri Convert(object value)
         {
             if (value == null)
                 throw new ArgumentNullException(nameof(value));
@@ -35,13 +52,13 @@ namespace Ycode.UriConvert
             if (baseUri == null)
                 throw new UriFormatException($"The object's Base URI Property {baseUriProperty.Name} was null.");
             
-            Uri uri = new Uri(baseUri);
+            System.Uri uri = new System.Uri(baseUri);
             if (path != null)
-                uri = (uri == null ? new Uri(path) : new Uri(uri, path));
+                uri = (uri == null ? new System.Uri(path) : new System.Uri(uri, path));
             if (queryParameters != null && queryParameters.Any())
                 uri = (uri == null
-                       ? new Uri("?" + queryParameters.SerializeQueryParameters())
-                       : new Uri(uri, "?" + queryParameters.SerializeQueryParameters()));
+                       ? new System.Uri("?" + queryParameters.SerializeQueryParameters())
+                       : new System.Uri(uri, "?" + queryParameters.SerializeQueryParameters()));
             return uri;
         }
 
@@ -215,7 +232,7 @@ namespace Ycode.UriConvert
         }
 
         private static string Escape(this string value)
-            => Uri.EscapeDataString(value);
+            => System.Uri.EscapeDataString(value);
 
         private static string SerializeQueryParameters(this IDictionary<string, string> parameters)
             => string.Join("&", parameters.Select(p => $"{p.Key}={p.Value}"));

--- a/UriConvert/src/UriConvertExtension.cs
+++ b/UriConvert/src/UriConvertExtension.cs
@@ -1,6 +1,27 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 namespace Ycode.UriConvert
+{
+    public static class UriConvertExtension
+    {
+        [Obsolete(UriConvert.ObsoleteMessage)]
+        public static System.Uri ToUri(this object value)
+            => UriConvert.Convert(value);
+
+        [Obsolete(UriConvert.ObsoleteMessage)]
+        public static string ToUriString(this object value)
+            => UriConvert.SerializeObject(value);
+
+        [Obsolete(UriConvert.ObsoleteMessage)]
+        public static IDictionary<string, string> ToUriQueryParameters(this object value, bool isToEncode = false)
+            => UriConvert.ExtractQueryParameters(value, isToEncode);
+    }
+}
+#pragma warning restore CS0618 // Type or member is obsolete
+
+namespace Ycode.Uri
 {
     public static class UriConvertExtension
     {

--- a/UriConvert/src/UriIgnoreAttribute.cs
+++ b/UriConvert/src/UriIgnoreAttribute.cs
@@ -2,6 +2,15 @@
 
 namespace Ycode.UriConvert
 {
+    [Obsolete(UriConvert.ObsoleteMessage)]
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    public class UriIgnoreAttribute : Ycode.Uri.UriIgnoreAttribute
+    {
+    }
+}
+
+namespace Ycode.Uri
+{
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
     public class UriIgnoreAttribute : Attribute
     {

--- a/UriConvert/src/UriPathAttribute.cs
+++ b/UriConvert/src/UriPathAttribute.cs
@@ -2,6 +2,15 @@
 
 namespace Ycode.UriConvert
 {
+    [Obsolete(UriConvert.ObsoleteMessage)]
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    public class UriPathAttribute : Ycode.Uri.UriPathAttribute
+    {
+    }
+}
+
+namespace Ycode.Uri
+{
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
     public class UriPathAttribute : Attribute
     {

--- a/UriConvert/src/UriQueryParameterAttribute.cs
+++ b/UriConvert/src/UriQueryParameterAttribute.cs
@@ -2,6 +2,18 @@
 
 namespace Ycode.UriConvert
 {
+    [Obsolete(UriConvert.ObsoleteMessage)]
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    public class UriQueryParameterAttribute : Ycode.Uri.UriQueryParameterAttribute
+    {
+        public UriQueryParameterAttribute(string name) : base(name) { }
+
+        public UriQueryParameterAttribute() : base() { }
+    }
+}
+
+namespace Ycode.Uri
+{
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
     public class UriQueryParameterAttribute : Attribute
     {


### PR DESCRIPTION
These changes resolve #2.

* rename Ycode.UriConvert namespace to Ycode.Uri
* add code to still support namespace Ycode.UriConvert but with obsolete annotation
